### PR TITLE
fix: More robust handling of non-dict metadata values

### DIFF
--- a/utils/metadata_tools.py
+++ b/utils/metadata_tools.py
@@ -23,20 +23,26 @@ def extract_exif(image: Image.Image) -> dict:
 
 def format_metadata(raw_exif: dict) -> dict:
     formatted = {}
-    for ifd_name in raw_exif:
-        if isinstance(raw_exif[ifd_name], dict):
-            formatted[ifd_name] = {}
-            for tag in raw_exif[ifd_name]:
-                try:
-                    tag_name = piexif.TAGS[ifd_name][tag]["name"]
-                    value = raw_exif[ifd_name][tag]
-                    if isinstance(value, bytes):
-                        value = value.decode(errors="ignore")
-                    formatted[ifd_name][tag_name] = value
-                except:
-                    pass
-        else:
-            formatted[ifd_name] = raw_exif[ifd_name]
+    for ifd_name, tags in raw_exif.items():
+        if not isinstance(tags, dict):
+            # If for some reason, tags are not a dict, we can't iterate .items()
+            # Let's create a placeholder to avoid crashing.
+            formatted[ifd_name] = {"Error": "Could not read metadata section."}
+            continue
+
+        formatted_tags = {}
+        for tag, value in tags.items():
+            try:
+                tag_name = piexif.TAGS[ifd_name][tag]["name"]
+            except KeyError:
+                tag_name = str(tag)  # Use the tag itself if not found
+
+            if isinstance(value, bytes):
+                value = value.decode(errors='ignore')
+
+            formatted_tags[tag_name] = value
+
+        formatted[ifd_name] = formatted_tags
     return formatted
 
 def strip_exif(image: Image.Image) -> io.BytesIO:


### PR DESCRIPTION
The previous fix was not sufficient to handle all cases of malformed metadata. This commit introduces a more robust version of the `format_metadata` function that ensures the `tags` variable is always a dictionary before processing. If the metadata for a section is not a dictionary, a placeholder error message is created to prevent the application from crashing.

This change will prevent the `AttributeError: 'str' object has no attribute 'items'` error and ensure the application remains stable when encountering unexpected metadata formats.