### PR TITLE
fix: Final robust handling of invalid metadata

### DIFF
--- a/app.py
+++ b/app.py
@@ -91,8 +91,11 @@ if uploaded_file is not None:
                 if tags:
                     has_data = True
                     with st.expander(f"📂 {section}"):
-                        for k, v in tags.items():
-                            st.markdown(f"- **{k}**: {v}")
+                        if isinstance(tags, dict):
+                            for k, v in tags.items():
+                                st.markdown(f"- **{k}**: {v}")
+                        else:
+                            st.markdown(f"- {tags}")
             if not has_data:
                 st.info("No visible metadata found in this image.")
         else:

--- a/utils/metadata_tools.py
+++ b/utils/metadata_tools.py
@@ -13,7 +13,11 @@ def extract_exif(image: Image.Image) -> dict:
     try:
         exif_data = image.info.get("exif")
         if exif_data:
-            return piexif.load(exif_data)
+            loaded_exif = piexif.load(exif_data)
+            if isinstance(loaded_exif, dict):
+                return loaded_exif
+            else:
+                return {"Error": "Invalid EXIF data."}
         elif "png" in image.format.lower():
             return {"PNG Info": image.info}
         else:
@@ -23,20 +27,26 @@ def extract_exif(image: Image.Image) -> dict:
 
 def format_metadata(raw_exif: dict) -> dict:
     formatted = {}
-    for ifd_name in raw_exif:
-        if isinstance(raw_exif[ifd_name], dict):
-            formatted[ifd_name] = {}
-            for tag in raw_exif[ifd_name]:
-                try:
-                    tag_name = piexif.TAGS[ifd_name][tag]["name"]
-                    value = raw_exif[ifd_name][tag]
-                    if isinstance(value, bytes):
-                        value = value.decode(errors="ignore")
-                    formatted[ifd_name][tag_name] = value
-                except:
-                    pass
-        else:
-            formatted[ifd_name] = raw_exif[ifd_name]
+    for ifd_name, tags in raw_exif.items():
+        if not isinstance(tags, dict):
+            # If for some reason, tags are not a dict, we can't iterate .items()
+            # Let's create a placeholder to avoid crashing.
+            formatted[ifd_name] = {"Error": "Could not read metadata section."}
+            continue
+
+        formatted_tags = {}
+        for tag, value in tags.items():
+            try:
+                tag_name = piexif.TAGS[ifd_name][tag]["name"]
+            except KeyError:
+                tag_name = str(tag)  # Use the tag itself if not found
+
+            if isinstance(value, bytes):
+                value = value.decode(errors='ignore')
+
+            formatted_tags[tag_name] = value
+
+        formatted[ifd_name] = formatted_tags
     return formatted
 
 def strip_exif(image: Image.Image) -> io.BytesIO:


### PR DESCRIPTION
This commit provides a comprehensive fix for the application crash on mobile devices. The crash was caused by invalid metadata that was not being handled correctly.

Changes:
- `extract_exif` now ensures that `piexif.load` returns a dictionary. If not, it returns a dictionary with an error message.
- `app.py` now checks if the `tags` variable is a dictionary before iterating over it. If not, it displays the value directly, which will show any error messages.

These changes make the application more robust and will prevent it from crashing when encountering invalid or unexpected metadata formats.